### PR TITLE
fix compilation issue on Linux

### DIFF
--- a/appleserialthing.c
+++ b/appleserialthing.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdint.h>
 
 int main(int argc, const char * argv[]) {
     


### PR DESCRIPTION
`uint32_t ` is not a default type on Linux distros : 
```
appleserialthing.c: In function ‘main’:
appleserialthing.c:49:13: error: unknown type name ‘uint32_t’
             uint32_t yearint = atoi(year);
             ^
appleserialthing.c:113:5: error: unknown type name ‘uint32_t’
     uint32_t yearmaybe = -1;
     ^
appleserialthing.c:128:5: error: unknown type name ‘uint32_t’
     uint32_t weekmaybe = -1;
```